### PR TITLE
Qt6 compatibility

### DIFF
--- a/color-schemes/IridescentLightly.colors
+++ b/color-schemes/IridescentLightly.colors
@@ -50,7 +50,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header]
 BackgroundAlternate=20,20,33
-BackgroundNormal=6,3,15,80
+BackgroundNormal=6,3,15
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -65,7 +65,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header][Inactive]
 BackgroundAlternate=20,20,33
-BackgroundNormal=6,3,15,80
+BackgroundNormal=6,3,15
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -121,7 +121,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Window]
 BackgroundAlternate=6,3,15
-BackgroundNormal=8,4,19,220
+BackgroundNormal=8,4,19
 DecorationFocus=6,3,15
 DecorationHover=16,158,230
 ForegroundActive=61,174,233
@@ -142,7 +142,7 @@ shadeSortColumn=true
 contrast=4
 
 [WM]
-activeBackground=8,4,19,80
+activeBackground=8,4,19
 activeBlend=6,3,15
 activeForeground=23,147,209
 inactiveBackground=6,3,15

--- a/color-schemes/IridescentLightly2.colors
+++ b/color-schemes/IridescentLightly2.colors
@@ -50,7 +50,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header]
 BackgroundAlternate=20,20,33
-BackgroundNormal=6,3,15,177
+BackgroundNormal=6,3,15
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -65,7 +65,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header][Inactive]
 BackgroundAlternate=20,20,33
-BackgroundNormal=6,3,15,177
+BackgroundNormal=6,3,15
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -121,7 +121,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Window]
 BackgroundAlternate=6,3,15
-BackgroundNormal=8,4,19,220
+BackgroundNormal=8,4,19
 DecorationFocus=6,3,15
 DecorationHover=16,158,230
 ForegroundActive=61,174,233
@@ -142,7 +142,7 @@ shadeSortColumn=true
 contrast=4
 
 [WM]
-activeBackground=8,4,19,177
+activeBackground=8,4,19
 activeBlend=6,3,15
 activeForeground=23,147,209
 inactiveBackground=6,3,15

--- a/color-schemes/IridescentLightly3.colors
+++ b/color-schemes/IridescentLightly3.colors
@@ -50,7 +50,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header]
 BackgroundAlternate=20,20,33
-BackgroundNormal=1,14,23,177
+BackgroundNormal=1,14,23
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -65,7 +65,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Header][Inactive]
 BackgroundAlternate=20,20,33
-BackgroundNormal=1,14,23,177
+BackgroundNormal=1,14,23
 DecorationFocus=7,110,163
 DecorationHover=16,158,230
 ForegroundActive=0,193,228
@@ -121,7 +121,7 @@ ForegroundVisited=124,183,255
 
 [Colors:Window]
 BackgroundAlternate=1,14,23
-BackgroundNormal=1,11,18,220
+BackgroundNormal=1,11,18
 DecorationFocus=1,14,23
 DecorationHover=16,158,230
 ForegroundActive=61,174,233
@@ -142,7 +142,7 @@ shadeSortColumn=true
 contrast=4
 
 [WM]
-activeBackground=1,11,18,177
+activeBackground=1,11,18
 activeBlend=1,14,23
 activeForeground=23,147,209
 inactiveBackground=1,14,23


### PR DESCRIPTION
It appears that there is an incompatibility between this color scheme and Qt6: the top-level widget always receives a light background. (Please note that everything works as expected on Qt5.)

I have no prior experience with themes and am unfamiliar with the file format. However, it seems this incompatibility can be resolved by removing the last value from `BackgroundNormal=8,4,19,220` within `[Colors:Window]`. Perhaps Qt6 does not support transparency well? While I'm unsure of the potential side effects of this change, I have tested it on Qt5 and observed no differences. Nevertheless, on Qt6, it successfully resolves the rendering issue.

This PR removes all transparency values. Strictly speaking, only [Colors:Window] BackgroundNormal would be necessary, but removing all occurrences might improve compatibility.

# Rendering on Qt6/Fusion with current master

![qt6actual](https://github.com/ddh4r4m/Iridescent/assets/6830724/5ef7cabf-8d6d-41e0-a5f8-5587b7755203)

# Rendering on Qt6/Fusion with this PR

![qt6expected](https://github.com/ddh4r4m/Iridescent/assets/6830724/4facdc72-19a6-42f3-b598-6c597435f5c1)
